### PR TITLE
Add ObjectHash implementation in Swift

### DIFF
--- a/swift/.gitignore
+++ b/swift/.gitignore
@@ -1,0 +1,80 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+**/Carthage
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# IDE
+.idea
+
+# Other
+.DS_Store
+
+# HockeySDK
+HockeySDK-iOS
+
+products

--- a/swift/HostApp/AppDelegate.swift
+++ b/swift/HostApp/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  HostApp
+//
+//  Created by Denis Zenin on 08/08/2018.
+//  Copyright © 2018 VChain Technology Limited. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/swift/HostApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/swift/HostApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/swift/HostApp/Assets.xcassets/Contents.json
+++ b/swift/HostApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/swift/HostApp/Base.lproj/LaunchScreen.storyboard
+++ b/swift/HostApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/swift/HostApp/Base.lproj/Main.storyboard
+++ b/swift/HostApp/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/swift/HostApp/Info.plist
+++ b/swift/HostApp/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/swift/HostApp/ViewController.swift
+++ b/swift/HostApp/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  HostApp
+//
+//  Created by Denis Zenin on 08/08/2018.
+//  Copyright © 2018 VChain Technology Limited. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/swift/ObjectHash.xcodeproj/project.pbxproj
+++ b/swift/ObjectHash.xcodeproj/project.pbxproj
@@ -1,0 +1,717 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0B57BBAB2121CD57004D1FC7 /* common_json.test in Resources */ = {isa = PBXBuildFile; fileRef = 0B57BBAA2121CD57004D1FC7 /* common_json.test */; };
+		0BA46866211B5C8C00946842 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA46865211B5C8C00946842 /* AppDelegate.swift */; };
+		0BA46868211B5C8C00946842 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA46867211B5C8C00946842 /* ViewController.swift */; };
+		0BA4686B211B5C8C00946842 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0BA46869211B5C8C00946842 /* Main.storyboard */; };
+		0BA4686D211B5C8E00946842 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0BA4686C211B5C8E00946842 /* Assets.xcassets */; };
+		0BA46870211B5C8E00946842 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0BA4686E211B5C8E00946842 /* LaunchScreen.storyboard */; };
+		0BC8F3B22119F29C00665018 /* ObjectHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BC8F3A42119F29C00665018 /* ObjectHash.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0BC8F3D1211B445900665018 /* ObjectHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC8F3D0211B445900665018 /* ObjectHashTests.swift */; };
+		0BC8F3D3211B445900665018 /* ObjectHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BC8F3A12119F29C00665018 /* ObjectHash.framework */; };
+		3566C70F8B847EB1107621BC /* ObjectHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3566CD54B4AB7FE557A86DDC /* ObjectHash.swift */; };
+		B1DD5664E79FC608575E00CD /* Pods_ObjectHashTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B14C8971F9C4685FA904F1F0 /* Pods_ObjectHashTests.framework */; };
+		D798DEEA2EF44CC438FF298B /* Pods_ObjectHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAA9B9E7FD19D49B9514A816 /* Pods_ObjectHash.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0BA46883211B5CA700946842 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0BC8F3982119F29C00665018 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0BA46862211B5C8C00946842;
+			remoteInfo = HostApp;
+		};
+		0BC8F3D4211B445900665018 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0BC8F3982119F29C00665018 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0BC8F3A02119F29C00665018;
+			remoteInfo = ObjectHash;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0B57BBAA2121CD57004D1FC7 /* common_json.test */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = common_json.test; sourceTree = "<group>"; };
+		0BA46863211B5C8C00946842 /* HostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BA46865211B5C8C00946842 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		0BA46867211B5C8C00946842 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		0BA4686A211B5C8C00946842 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		0BA4686C211B5C8E00946842 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		0BA4686F211B5C8E00946842 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		0BA46871211B5C8E00946842 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0BC8F3A12119F29C00665018 /* ObjectHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BC8F3A42119F29C00665018 /* ObjectHash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjectHash.h; sourceTree = "<group>"; };
+		0BC8F3A52119F29C00665018 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0BC8F3CE211B445900665018 /* ObjectHashTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectHashTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BC8F3D0211B445900665018 /* ObjectHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectHashTests.swift; sourceTree = "<group>"; };
+		0BC8F3D2211B445900665018 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0C1489251D04EA506A243533 /* Pods-ObjectHash.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectHash.release.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectHash/Pods-ObjectHash.release.xcconfig"; sourceTree = "<group>"; };
+		3566CD54B4AB7FE557A86DDC /* ObjectHash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectHash.swift; sourceTree = "<group>"; };
+		4CBCCC5B6F5E4BCF8E24604E /* Pods-ObjectHash.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectHash.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectHash/Pods-ObjectHash.debug.xcconfig"; sourceTree = "<group>"; };
+		646C1FFF12326C408ABE8DCD /* Pods-ObjectHashTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectHashTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectHashTests/Pods-ObjectHashTests.release.xcconfig"; sourceTree = "<group>"; };
+		AAA9B9E7FD19D49B9514A816 /* Pods_ObjectHash.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ObjectHash.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B14C8971F9C4685FA904F1F0 /* Pods_ObjectHashTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ObjectHashTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB86EB8F5BA11A6C7E72073B /* Pods-ObjectHashTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectHashTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectHashTests/Pods-ObjectHashTests.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0BA46860211B5C8C00946842 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC8F39D2119F29C00665018 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D798DEEA2EF44CC438FF298B /* Pods_ObjectHash.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC8F3CB211B445900665018 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BC8F3D3211B445900665018 /* ObjectHash.framework in Frameworks */,
+				B1DD5664E79FC608575E00CD /* Pods_ObjectHashTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0BA46864211B5C8C00946842 /* HostApp */ = {
+			isa = PBXGroup;
+			children = (
+				0BA46865211B5C8C00946842 /* AppDelegate.swift */,
+				0BA46867211B5C8C00946842 /* ViewController.swift */,
+				0BA46869211B5C8C00946842 /* Main.storyboard */,
+				0BA4686C211B5C8E00946842 /* Assets.xcassets */,
+				0BA4686E211B5C8E00946842 /* LaunchScreen.storyboard */,
+				0BA46871211B5C8E00946842 /* Info.plist */,
+			);
+			path = HostApp;
+			sourceTree = "<group>";
+		};
+		0BC8F3972119F29C00665018 = {
+			isa = PBXGroup;
+			children = (
+				0BC8F3A32119F29C00665018 /* ObjectHash */,
+				0BC8F3CF211B445900665018 /* ObjectHashTests */,
+				0BA46864211B5C8C00946842 /* HostApp */,
+				0BC8F3A22119F29C00665018 /* Products */,
+				90C56A6FA409FF248ED82198 /* Pods */,
+				2D850B0B44AE82304458621A /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		0BC8F3A22119F29C00665018 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0BC8F3A12119F29C00665018 /* ObjectHash.framework */,
+				0BC8F3CE211B445900665018 /* ObjectHashTests.xctest */,
+				0BA46863211B5C8C00946842 /* HostApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0BC8F3A32119F29C00665018 /* ObjectHash */ = {
+			isa = PBXGroup;
+			children = (
+				0BC8F3A42119F29C00665018 /* ObjectHash.h */,
+				0BC8F3A52119F29C00665018 /* Info.plist */,
+				3566CD54B4AB7FE557A86DDC /* ObjectHash.swift */,
+			);
+			path = ObjectHash;
+			sourceTree = "<group>";
+		};
+		0BC8F3CF211B445900665018 /* ObjectHashTests */ = {
+			isa = PBXGroup;
+			children = (
+				0B57BBAA2121CD57004D1FC7 /* common_json.test */,
+				0BC8F3D0211B445900665018 /* ObjectHashTests.swift */,
+				0BC8F3D2211B445900665018 /* Info.plist */,
+			);
+			path = ObjectHashTests;
+			sourceTree = "<group>";
+		};
+		2D850B0B44AE82304458621A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AAA9B9E7FD19D49B9514A816 /* Pods_ObjectHash.framework */,
+				B14C8971F9C4685FA904F1F0 /* Pods_ObjectHashTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		90C56A6FA409FF248ED82198 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4CBCCC5B6F5E4BCF8E24604E /* Pods-ObjectHash.debug.xcconfig */,
+				0C1489251D04EA506A243533 /* Pods-ObjectHash.release.xcconfig */,
+				CB86EB8F5BA11A6C7E72073B /* Pods-ObjectHashTests.debug.xcconfig */,
+				646C1FFF12326C408ABE8DCD /* Pods-ObjectHashTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0BC8F39E2119F29C00665018 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BC8F3B22119F29C00665018 /* ObjectHash.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		0BA46862211B5C8C00946842 /* HostApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0BA46881211B5C8E00946842 /* Build configuration list for PBXNativeTarget "HostApp" */;
+			buildPhases = (
+				0BA4685F211B5C8C00946842 /* Sources */,
+				0BA46860211B5C8C00946842 /* Frameworks */,
+				0BA46861211B5C8C00946842 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HostApp;
+			productName = HostApp;
+			productReference = 0BA46863211B5C8C00946842 /* HostApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		0BC8F3A02119F29C00665018 /* ObjectHash */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0BC8F3B52119F29C00665018 /* Build configuration list for PBXNativeTarget "ObjectHash" */;
+			buildPhases = (
+				9658BC9EFFDC6837A9616D98 /* [CP] Check Pods Manifest.lock */,
+				0BC8F39C2119F29C00665018 /* Sources */,
+				0BC8F39D2119F29C00665018 /* Frameworks */,
+				0BC8F39E2119F29C00665018 /* Headers */,
+				0BC8F39F2119F29C00665018 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ObjectHash;
+			productName = ObjectHash;
+			productReference = 0BC8F3A12119F29C00665018 /* ObjectHash.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		0BC8F3CD211B445900665018 /* ObjectHashTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0BC8F3D6211B445900665018 /* Build configuration list for PBXNativeTarget "ObjectHashTests" */;
+			buildPhases = (
+				C12BBF70AD00311B66A87436 /* [CP] Check Pods Manifest.lock */,
+				0BC8F3CA211B445900665018 /* Sources */,
+				0BC8F3CB211B445900665018 /* Frameworks */,
+				0BC8F3CC211B445900665018 /* Resources */,
+				8819149318D4AD541FDFF8F7 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0BC8F3D5211B445900665018 /* PBXTargetDependency */,
+				0BA46884211B5CA700946842 /* PBXTargetDependency */,
+			);
+			name = ObjectHashTests;
+			productName = ObjectHashTests;
+			productReference = 0BC8F3CE211B445900665018 /* ObjectHashTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0BC8F3982119F29C00665018 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0940;
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = "VChain Technology Limited";
+				TargetAttributes = {
+					0BA46862211B5C8C00946842 = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+					0BC8F3A02119F29C00665018 = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+					0BC8F3CD211B445900665018 = {
+						CreatedOnToolsVersion = 9.4.1;
+						TestTargetID = 0BA46862211B5C8C00946842;
+					};
+				};
+			};
+			buildConfigurationList = 0BC8F39B2119F29C00665018 /* Build configuration list for PBXProject "ObjectHash" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0BC8F3972119F29C00665018;
+			productRefGroup = 0BC8F3A22119F29C00665018 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0BC8F3A02119F29C00665018 /* ObjectHash */,
+				0BC8F3CD211B445900665018 /* ObjectHashTests */,
+				0BA46862211B5C8C00946842 /* HostApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0BA46861211B5C8C00946842 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BA46870211B5C8E00946842 /* LaunchScreen.storyboard in Resources */,
+				0BA4686D211B5C8E00946842 /* Assets.xcassets in Resources */,
+				0BA4686B211B5C8C00946842 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC8F39F2119F29C00665018 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC8F3CC211B445900665018 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B57BBAB2121CD57004D1FC7 /* common_json.test in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		8819149318D4AD541FDFF8F7 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-ObjectHashTests/Pods-ObjectHashTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectHashTests/Pods-ObjectHashTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9658BC9EFFDC6837A9616D98 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ObjectHash-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C12BBF70AD00311B66A87436 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ObjectHashTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0BA4685F211B5C8C00946842 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BA46868211B5C8C00946842 /* ViewController.swift in Sources */,
+				0BA46866211B5C8C00946842 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC8F39C2119F29C00665018 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3566C70F8B847EB1107621BC /* ObjectHash.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0BC8F3CA211B445900665018 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0BC8F3D1211B445900665018 /* ObjectHashTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0BA46884211B5CA700946842 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0BA46862211B5C8C00946842 /* HostApp */;
+			targetProxy = 0BA46883211B5CA700946842 /* PBXContainerItemProxy */;
+		};
+		0BC8F3D5211B445900665018 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0BC8F3A02119F29C00665018 /* ObjectHash */;
+			targetProxy = 0BC8F3D4211B445900665018 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		0BA46869211B5C8C00946842 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0BA4686A211B5C8C00946842 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		0BA4686E211B5C8E00946842 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				0BA4686F211B5C8E00946842 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		0BA4687D211B5C8E00946842 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = CR8X7HC4Z9;
+				INFOPLIST_FILE = HostApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = vchain.HostApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0BA4687E211B5C8E00946842 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = CR8X7HC4Z9;
+				INFOPLIST_FILE = HostApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = vchain.HostApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		0BC8F3B32119F29C00665018 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		0BC8F3B42119F29C00665018 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0BC8F3B62119F29C00665018 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4CBCCC5B6F5E4BCF8E24604E /* Pods-ObjectHash.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = CR8X7HC4Z9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ObjectHash/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = vchain.ObjectHash;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		0BC8F3B72119F29C00665018 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0C1489251D04EA506A243533 /* Pods-ObjectHash.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = CR8X7HC4Z9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ObjectHash/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = vchain.ObjectHash;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		0BC8F3D7211B445900665018 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB86EB8F5BA11A6C7E72073B /* Pods-ObjectHashTests.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = CR8X7HC4Z9;
+				INFOPLIST_FILE = ObjectHashTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = vchain.ObjectHashTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
+			};
+			name = Debug;
+		};
+		0BC8F3D8211B445900665018 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 646C1FFF12326C408ABE8DCD /* Pods-ObjectHashTests.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = CR8X7HC4Z9;
+				INFOPLIST_FILE = ObjectHashTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = vchain.ObjectHashTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HostApp.app/HostApp";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0BA46881211B5C8E00946842 /* Build configuration list for PBXNativeTarget "HostApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0BA4687D211B5C8E00946842 /* Debug */,
+				0BA4687E211B5C8E00946842 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0BC8F39B2119F29C00665018 /* Build configuration list for PBXProject "ObjectHash" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0BC8F3B32119F29C00665018 /* Debug */,
+				0BC8F3B42119F29C00665018 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0BC8F3B52119F29C00665018 /* Build configuration list for PBXNativeTarget "ObjectHash" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0BC8F3B62119F29C00665018 /* Debug */,
+				0BC8F3B72119F29C00665018 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0BC8F3D6211B445900665018 /* Build configuration list for PBXNativeTarget "ObjectHashTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0BC8F3D7211B445900665018 /* Debug */,
+				0BC8F3D8211B445900665018 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0BC8F3982119F29C00665018 /* Project object */;
+}

--- a/swift/ObjectHash.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift/ObjectHash.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ObjectHash.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/swift/ObjectHash.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swift/ObjectHash.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swift/ObjectHash.xcworkspace/contents.xcworkspacedata
+++ b/swift/ObjectHash.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:ObjectHash.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/swift/ObjectHash.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swift/ObjectHash.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swift/ObjectHash/Info.plist
+++ b/swift/ObjectHash/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/swift/ObjectHash/ObjectHash.h
+++ b/swift/ObjectHash/ObjectHash.h
@@ -1,0 +1,19 @@
+//
+//  ObjectHash.h
+//  ObjectHash
+//
+//  Created by Denis Zenin on 07/08/2018.
+//  Copyright © 2018 VChain Technology Limited. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for ObjectHash.
+FOUNDATION_EXPORT double ObjectHashVersionNumber;
+
+//! Project version string for ObjectHash.
+FOUNDATION_EXPORT const unsigned char ObjectHashVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ObjectHash/PublicHeader.h>
+
+

--- a/swift/ObjectHash/ObjectHash.swift
+++ b/swift/ObjectHash/ObjectHash.swift
@@ -1,0 +1,362 @@
+import CryptoSwift
+
+public typealias Byte = UInt8
+public typealias BytesArray = [Byte]
+public typealias Object = [String: Any]
+
+public class ObjectHash {
+    public internal(set) var hash: BytesArray = []
+    private var digester = SHA2(variant: .sha256)
+    
+    public class func fromHex(hex: String) throws -> ObjectHash {
+        let h = ObjectHash()
+        var hex = hex.lowercased()
+
+        if hex.count % 2 == 1 {
+            hex = "0" + hex
+        }
+        
+        for idx in stride(from: hex.count, to: 0, by: -2) {
+            let firstChar = hex[idx - 2]
+            let secondChar = hex[idx - 1]
+            let num = try 16 * parseHex(char: firstChar) + parseHex(char: secondChar)
+
+            h.hash.insert(Byte(num), at: 0)
+        }
+
+        return h
+    }
+
+    private class func parseHex(char: Character) throws -> Int {
+        guard let num = Int(String(char), radix: 16) else {
+            throw ErrorObjectHash.invalidHexStringCharacter
+        }
+
+        return num
+    }
+
+    public func toString() -> String {
+        return convertToHex(hash)
+    }
+    
+    public class func fromBytes(hash: BytesArray) -> ObjectHash {
+        let h = ObjectHash();
+        h.hash = hash
+
+        return h
+    }
+
+    private func getType(_ jsonObj: Any) -> JsonType {
+        if jsonObj is NSNull {
+            return .null
+        }
+
+        if isJsonBool(jsonObj) {
+            return .boolean
+        }
+
+        if jsonObj is Int || jsonObj is Double {
+            return .number
+        }
+
+        if isJsonArray(jsonObj) {
+            return .array
+        }
+
+        if let _ = jsonObj as? Object {
+            return .object
+        }
+
+        if let s = jsonObj as? String {
+            if s.starts(with: Redacted.PREFIX) {
+                return .redacted
+            }
+
+            return .string
+        }
+
+        return .unknown
+    }
+
+    private func isJsonBool(_ value: Any) -> Bool {
+        return type(of: value) == type(of: NSNumber(value: true))
+    }
+
+    private func isJsonArray(_ x: Any) -> Bool {
+        if let _ = x as? [Any] {
+            return true
+        }
+        if let _ = x as? [AnyObject] {
+            return true
+        }
+        if let _ = x as? NSArray {
+            return true
+        }
+
+        return false
+    }
+
+    class func normalizeFloat(_ float: Double) throws -> String {
+        var f = float
+        // Early our for zero
+        if f == 0.0 {
+            return "+0:"
+        }
+
+        var normString = ""
+        var sign = "+"
+        if f < 0.0 {
+
+            sign = "-"
+            f = -f
+        }
+
+        normString += sign
+
+        // Exponent
+        var e = 0
+        while f > 1 {
+            f /= 2
+            e += 1
+        }
+        while f < 0.5 {
+            f *= 2
+            e -= 1
+        }
+
+        normString += "\(e):"
+
+        // Mantissa
+        if f > 1 || f <= 0.5 {
+            throw ErrorObjectHash.wrongRangeForMantissa
+        }
+
+        while f != 0 {
+            if f >= 1 {
+                normString += "1"
+                f -= 1
+            } else {
+                normString += "0"
+            }
+
+            if f >= 1 {
+                throw ErrorObjectHash.floatIsTooBig
+            }
+
+            if normString.count > 1000 {
+                throw ErrorObjectHash.floatIsTooBig
+            }
+
+            f *= 2
+        }
+
+        return normString
+    }
+    
+    private func hashTaggedBytes(tag: String, bytes: BytesArray) throws {
+        _ = try digester.update(withBytes: tag.toBytes() + bytes)
+        hash = try digester.finish()
+    }
+
+    private func hashString(_ str: String) throws {
+        try hashTaggedBytes(tag: "u", bytes: str.toBytes())
+    }
+
+    private func hashNumber(_ double: Double) throws {
+        let normalized = try ObjectHash.normalizeFloat(double)
+        try hashTaggedBytes(tag: "f", bytes: normalized.toBytes())
+    }
+
+    private func hashNull() throws {
+        try hashTaggedBytes(tag: "n", bytes: [])
+    }
+
+    private func hashBoolean(bool: Bool) throws {
+        let boolString = bool ? "1" : "0"
+        try hashTaggedBytes(tag: "b", bytes: boolString.toBytes())
+    }
+    
+    private func hashAny(_ object: Any) throws {
+        let outerType = getType(object)
+
+        switch outerType {
+        case .array: try hashList(object as! [Any])
+        case .object: try hashObject(object as! [String: Any])
+        case .string: try hashString(object as! String)
+        case .boolean: try hashBoolean(bool: object as! Bool)
+        case .number: try hashNumber(object as! Double)
+        case .redacted: hash = try Redacted.fromString(object as! String).hash;
+        case .null: try hashNull()
+        default: throw ErrorObjectHash.illegalTypeInJSON(type: outerType.rawValue)
+        }
+    }
+
+    private func hashList(_ list: [Any]) throws {
+        resetDigester()
+        _ = try digester.update(withBytes: "l".toBytes())
+
+        for element in list {
+            let innerObject = ObjectHash()
+            try innerObject.hashAny(element)
+            _ = try digester.update(withBytes: innerObject.hash)
+        }
+
+        hash = try digester.finish()
+    }
+
+    private func hashObject(_ object: Object) throws {
+        let keys = Array(object.keys)
+        var keysIterator = keys.makeIterator()
+
+        var buffers: [BytesArray] = []
+
+        while let key = keysIterator.next() {
+            //todo: experiment with chaining
+            var buff: BytesArray = []
+            let hKey = ObjectHash()
+            try hKey.hashString(key)
+            
+            guard let value = object[key] else {
+                throw ErrorObjectHash.missingValueInDictionary
+            }
+            
+            let hVal = ObjectHash()
+            try hVal.hashAny(value)
+
+            buff += hKey.hash
+            buff += hVal.hash
+
+            buffers.append(buff)
+        }
+
+        buffers.sort(by: <)
+        resetDigester()
+        _ = try digester.update(withBytes: "d".toBytes())
+
+        for buff in buffers {
+            _ = try digester.update(withBytes: buff)
+        }
+
+        hash = try digester.finish()
+    }
+
+    public class func pythonJsonHash(json: String) throws -> ObjectHash {
+        let h = ObjectHash()
+        let jsonObj = try getJsonObject(from: json)
+
+        try h.hashAny(jsonObj)
+        return h
+    }
+
+    private class func getJsonObject(from text: String) throws -> Any {
+        guard let data = text.data(using: .utf8) else {
+            throw ErrorObjectHash.invalidJsonString
+        }
+
+        // to prevent JSONSerialization treating floating point numbers as NSDecimal
+        // because NSDecimal has radix 10 and differs from Double (radix 2)
+        if let floatingPointNumber = Double(text) {
+            return floatingPointNumber
+        }
+
+        guard let jsonObj = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) else {
+            throw ErrorObjectHash.invalidJson
+        }
+
+        return jsonObj
+    }
+
+    private func resetDigester() {
+        digester = SHA2(variant: .sha256)
+    }
+
+    private enum JsonType: String {
+        case boolean
+        case array
+        case object
+        case number
+        case string
+        case null
+        case unknown
+        case redacted
+    }
+}
+
+func convertToHex(_ buffer: BytesArray) -> String {
+    var hexString = ""
+
+    for byte in buffer {
+        let hex = String(format: "%02X", byte)
+        hexString.append(hex)
+    }
+
+    return hexString.lowercased()
+}
+
+extension ObjectHash: Equatable {
+    static public func ==(lhs: ObjectHash, rhs: ObjectHash) -> Bool {
+        if lhs.toString() != rhs.toString() {
+            return false
+        }
+
+        return true
+    }
+}
+
+extension ObjectHash: Comparable {
+    static public func <(lhs: ObjectHash, rhs: ObjectHash) -> Bool {
+        return lhs.toString() < rhs.toString()
+    }
+}
+
+class Redacted: ObjectHash {
+    public static let PREFIX = "**REDACTED**"
+    
+    public class func fromString(_ representation: String) throws -> Redacted {
+        let hexString = representation.replacingOccurrences(of: Redacted.PREFIX, with: "")
+        let underlyingHash = try self.fromHex(hex: hexString)
+        return Redacted(hash: underlyingHash.hash)
+    }
+    
+    init(hash: BytesArray) {
+        super.init()
+        self.hash = hash
+    }
+
+    override class func pythonJsonHash(json: String) throws -> Redacted {
+        let hash = try ObjectHash.pythonJsonHash(json: json).hash
+        
+        return Redacted(hash: hash)
+    }
+    
+    override public func toString() -> String {
+        return "\(Redacted.PREFIX)\(super.toString())"
+    }
+}
+
+extension Array where Element == Byte {
+    static public func <(lhs: BytesArray, rhs: BytesArray) -> Bool {
+        return convertToHex(lhs) < convertToHex(rhs)
+    }
+}
+
+extension String {
+    subscript(i: Int) -> Character {
+        return self[index(startIndex, offsetBy: i)]
+    }
+
+    func toBytes() -> BytesArray {
+        return Array(self.utf8)
+    }
+}
+
+enum ErrorObjectHash: Error {
+    case invalidHexStringCharacter
+    case wrongRangeForMantissa
+    case floatIsTooBig
+    case normalizedFloatLengthIsTooBig
+    case illegalTypeInJSON(type: String)
+    case invalidJson
+    case invalidJsonString
+    case missingValueInDictionary
+}

--- a/swift/ObjectHashTests/Info.plist
+++ b/swift/ObjectHashTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/swift/ObjectHashTests/ObjectHashTests.swift
+++ b/swift/ObjectHashTests/ObjectHashTests.swift
@@ -1,0 +1,121 @@
+//
+//  ObjectHashTests.swift
+//  ObjectHashTests
+//
+//  Created by Denis Zenin on 08/08/2018.
+//  Copyright © 2018 VChain Technology Limited. All rights reserved.
+//
+
+@testable import ObjectHash
+
+import XCTest
+
+class ObjectHashTests: XCTestCase {
+    func testToHex() {
+        let testString = "\"SUP MELLO?\""
+        let expectedHashString = "a45b200d2032a5f9960f99bbb01cc81ca311a3c4abc9d51ddc87ea39f9588e54"
+
+        do {
+            let hash = try ObjectHash.pythonJsonHash(json: testString)
+            XCTAssertEqual(expectedHashString, hash.toString())
+        } catch {
+            print("ERROR: ", error)
+            XCTFail()
+        }
+    }
+
+    func testNumberNormalization() {
+        let expectedNormalizations = [
+            1.0: "+0:1",
+            1.5: "+1:011",
+            2.0: "+1:1",
+            1000.0: "+10:01111101",
+            0.0001: "+-13:011010001101101110001011101011000111000100001100101101",
+            -23.1234: "-5:010111000111111001011100100100011101000101001110001111"
+        ]
+
+        for expectation in expectedNormalizations {
+            let normalized = try! ObjectHash.normalizeFloat(expectation.key)
+            XCTAssertEqual(expectation.value, normalized)
+        }
+    }
+
+    func runTest(json: String, expectedHash: String) throws {
+        let expected = try ObjectHash.fromHex(hex: expectedHash).toString()
+        let hash = try ObjectHash.pythonJsonHash(json: json).toString()
+
+        XCTAssertEqual(expected, hash)
+    }
+
+    func test32BitIntegers() throws {
+        try runTest(
+            json: "[123]",
+            expectedHash: "2e72db006266ed9cdaa353aa22b9213e8a3c69c838349437c06896b1b34cee36"
+        );
+        try runTest(json: "[1, 2, 3]",
+            expectedHash: "925d474ac71f6e8cb35dd951d123944f7cabc5cda9a043cf38cd638cc0158db0"
+        );
+    }
+
+    func test64BitIntegers() throws {
+        try runTest(
+            json: "[123456789012345]",
+            expectedHash: "f446de5475e2f24c0a2b0cd87350927f0a2870d1bb9cbaa794e789806e4c0836"
+        );
+        try runTest(
+            json: "[123456789012345, 678901234567890]",
+            expectedHash: "d4cca471f1c68f62fbc815b88effa7e52e79d110419a7c64c1ebb107b07f7f56"
+        );
+    }
+
+    func testWithCommonObjectHashTests() {
+        let bundle = Bundle(for: type(of: self))
+        if let path = bundle.path(forResource: "common_json", ofType: "test") {
+            do {
+                let data = try String(contentsOfFile: path, encoding: .utf8)
+                let fileLines = data.components(separatedBy: .newlines)
+                var linesIterator = fileLines.makeIterator()
+
+                while let line = linesIterator.next() {
+                    if line.isEmpty || line.starts(with: "#") || line.starts(with: "~#") {
+                        continue
+                    }
+
+                    if let nextLine = linesIterator.next() {
+                        try runTest(json: line, expectedHash: nextLine)
+                    }
+                }
+            } catch {
+                print("COMMON TEST FAILED. ERROR: \(error)")
+                XCTFail()
+            }
+        }
+    }
+
+    func testHashRedaction() throws {
+        let jsonPart = "{\"field1\": \"value\", \"field2\": \"value2\"}"
+        let partHash = try ObjectHash.pythonJsonHash(json: jsonPart)
+        let redactedPartHash = try Redacted.pythonJsonHash(json: jsonPart)
+
+        let jsonFull = "{\"field3\": \"value3\", \"part\": \(jsonPart)}";
+        let jsonFullWithRedacted = "{\"field3\": \"value3\", \"part\": \"\(redactedPartHash.toString())\"}";
+
+        XCTAssertTrue(jsonFullWithRedacted.contains(partHash.toString()))
+
+        let fullHash = try ObjectHash.pythonJsonHash(json: jsonFull)
+        let fullWithRedactedHash = try ObjectHash.pythonJsonHash(json: jsonFullWithRedacted)
+
+        XCTAssertEqual(fullHash, fullWithRedactedHash)
+    }
+
+    func testRedactedHashWorksSimilarToObjectHash() throws {
+        let jsonPart = "{\"field1\": \"value\", \"field2\": \"value2\"}"
+        let objectHashString = try ObjectHash.pythonJsonHash(json: jsonPart).toString()
+
+        let redactedHashString = try Redacted.pythonJsonHash(json: jsonPart).toString()
+        let redactedHashStringCleaned = redactedHashString.replacingOccurrences(of: Redacted.PREFIX, with: "")
+
+        XCTAssertNotEqual(objectHashString, redactedHashString)
+        XCTAssertEqual(objectHashString, redactedHashStringCleaned)
+    }
+}

--- a/swift/ObjectHashTests/common_json.test
+++ b/swift/ObjectHashTests/common_json.test
@@ -1,0 +1,71 @@
+## -*- coding: utf-8 -*-
+
+# Lists with strings
+[]
+acac86c0e609ca906f632b0e2dacccb2b77d22b0621f20ebece1a4835b93f6f0
+["foo"]
+268bc27d4974d9d576222e4cdbb8f7c6bd6791894098645a19eeca9c102d0964
+["foo", "bar"]
+32ae896c413cfdc79eec68be9139c86ded8b279238467c216cf2bec4d5f1e4a2
+
+# Lists with ints
+[123]
+2e72db006266ed9cdaa353aa22b9213e8a3c69c838349437c06896b1b34cee36
+[1, 2, 3]
+925d474ac71f6e8cb35dd951d123944f7cabc5cda9a043cf38cd638cc0158db0
+[123456789012345]
+f446de5475e2f24c0a2b0cd87350927f0a2870d1bb9cbaa794e789806e4c0836
+[123456789012345, 678901234567890]
+d4cca471f1c68f62fbc815b88effa7e52e79d110419a7c64c1ebb107b07f7f56
+
+# Objects with (lists of) strings
+{}
+18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4
+{"foo": "bar"}
+7ef5237c3027d6c58100afadf37796b3d351025cf28038280147d42fdc53b960
+{"foo": ["bar", "baz"], "qux": ["norf"]}
+f1a9389f27558538a064f3cc250f8686a0cebb85f1cab7f4d4dcc416ceda3c92
+
+# Null values
+[null]
+5fb858ed3ef4275e64c2d5c44b77534181f7722b7765288e76924ce2f9f7f7db
+
+# Boolean primitives
+true
+7dc96f776c8423e57a2785489a3f9c43fb6e756876d6ad9a9cac4aa4e72ec193
+false
+c02c0b965e023abee808f2b548d8d5193a8b5229be6f3121a6f16e2d41a449b3
+
+# Floating point
+0.0
+60101d8c9cb988411468e38909571f357daa67bff5a7b0a3f9ae295cd4aba33d
+1.2345
+844e08b1195a93563db4e5d4faa59759ba0e0397caf065f3b6bc0825499754e0
+-10.1234
+59b49ae24998519925833e3ff56727e5d4868aba4ecf4c53653638ebff53c366
+
+# Mixture of all types
+["foo", {"bar": ["baz", null, 1.0, 1.5, 0.0001, 1000.0, 2.0, -23.1234, 2.0]}]
+783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213
+# Integers and floats are the same in common JSON
+["foo", {"bar": ["baz", null, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2]}]
+783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213
+# changing just a key changes the hash
+["foo", {"b4r": ["baz", null, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2]}]
+7e01f8b45da35386e4f9531ff1678147a215b8d2b1d047e690fd9ade6151e431
+
+# Test order independence
+{"k1": "v1", "k2": "v2", "k3": "v3"}
+ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057
+{"k2": "v2", "k1": "v1", "k3": "v3"}
+ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057
+
+# Unicode
+"ԱԲաբ"
+2a2a4485a4e338d8df683971956b1090d2f5d33955a81ecaad1a75125f7a316c
+"\u03d3"
+f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d
+# Note that this is the same character as above, but hashes differently unless
+# unicode normalisation is applied
+"\u03d2\u0301"
+42d5b13fb064849a988a86eb7650a22881c0a9ecf77057a1b07ab0dad385889c

--- a/swift/Podfile
+++ b/swift/Podfile
@@ -1,0 +1,13 @@
+platform :ios, '8.0'
+use_frameworks!
+
+target 'ObjectHash' do
+  pod 'CryptoSwift'
+
+  target 'ObjectHashTests' do
+    inherit! :search_paths
+  end
+end
+
+
+

--- a/swift/Podfile.lock
+++ b/swift/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - CryptoSwift (0.11.0)
+
+DEPENDENCIES:
+  - CryptoSwift
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CryptoSwift
+
+SPEC CHECKSUMS:
+  CryptoSwift: ad5208dd2aae0a764ea4ce2c2d34bd067cae67f0
+
+PODFILE CHECKSUM: b87136f14af32b15fe11082ea3a63b655b26183e
+
+COCOAPODS: 1.5.2


### PR DESCRIPTION
# NOTE!

Please do not review anything connected with `HostApp`. It is just default boilerplate code generated by XCode.
`HostApp` is needed to run tests on framework.
I will find better solution for this in the nearest future.